### PR TITLE
Ignore non-existing pods on mass deletion

### DIFF
--- a/pod-mass-restart
+++ b/pod-mass-restart
@@ -124,7 +124,7 @@ while read -r raw; do
 
   if wanted "$namespace" "$name" "${podpvc[@]}" && \
      [[ -n "$opt_delete_pods" ]]; then
-    oc -n "$namespace" delete pod "$name"
+    oc -n "$namespace" delete --ignore-not-found pod "$name"
     sleep 1
   fi
 


### PR DESCRIPTION
Without the "--ignore-not-found" flag a pod no longer in existence will
cause an error, thus aborting the script.