### PR TITLE
pod-mass-restart: Remove delay after deleting pod

### DIFF
--- a/pod-mass-restart
+++ b/pod-mass-restart
@@ -125,7 +125,6 @@ while read -r raw; do
   if wanted "$namespace" "$name" "${podpvc[@]}" && \
      [[ -n "$opt_delete_pods" ]]; then
     oc -n "$namespace" delete --ignore-not-found pod "$name"
-    sleep 1
   fi
 
   echo


### PR DESCRIPTION
The delay of a second after deleting a pod causes the script to run
unnecessarily slow on clusters with many matching pods.